### PR TITLE
Change app name to travel-app

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -3,7 +3,7 @@
   "version": 1,
   "newProjectRoot": "projects",
   "projects": {
-    "sassy-project": {
+    "travel-app": {
       "root": "",
       "sourceRoot": "src",
       "projectType": "application",
@@ -17,7 +17,7 @@
         "build": {
           "builder": "@angular-devkit/build-angular:browser",
           "options": {
-            "outputPath": "dist/sassy-project",
+            "outputPath": "dist/travel-app",
             "index": "src/index.html",
             "main": "src/main.ts",
             "polyfills": "src/polyfills.ts",
@@ -53,18 +53,18 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "sassy-project:build"
+            "browserTarget": "travel-app:build"
           },
           "configurations": {
             "production": {
-              "browserTarget": "sassy-project:build:production"
+              "browserTarget": "travel-app:build:production"
             }
           }
         },
         "extract-i18n": {
           "builder": "@angular-devkit/build-angular:extract-i18n",
           "options": {
-            "browserTarget": "sassy-project:build"
+            "browserTarget": "travel-app:build"
           }
         },
         "test": {
@@ -88,7 +88,7 @@
         }
       }
     },
-    "sassy-project-e2e": {
+    "travel-app-e2e": {
       "root": "e2e/",
       "projectType": "application",
       "architect": {
@@ -96,7 +96,7 @@
           "builder": "@angular-devkit/build-angular:protractor",
           "options": {
             "protractorConfig": "e2e/protractor.conf.js",
-            "devServerTarget": "sassy-project:serve"
+            "devServerTarget": "travel-app:serve"
           }
         },
         "lint": {
@@ -109,5 +109,5 @@
       }
     }
   },
-  "defaultProject": "sassy-project"
+  "defaultProject": "travel-app"
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "sassy-project",
+  "name": "travel-app",
   "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "sassy-project",
+  "name": "travel-app",
   "version": "0.0.0",
   "scripts": {
     "ng": "ng",


### PR DESCRIPTION
I understand it could be a reason of naming, so this PR is just a proposal:
- stick to `travel-app`
- configuration changes
- references updated