### PR TITLE
fix(icons) Fixed unnecessary spacing in size attributes

### DIFF
--- a/src/app/nav-transition/nav-transition.component.html
+++ b/src/app/nav-transition/nav-transition.component.html
@@ -1,41 +1,44 @@
 <div>
-  <div #profile *ngFor="let user of users; let i = index" (click)="changeUser(i)" [ngClass]="getClasses(user, i)">
-    <div class=" online "></div>
-    <img [src]="user.img " />
+  <div #profile
+       *ngFor="let user of users; let i = index"
+       (click)="changeUser(i)"
+       [ngClass]="getClasses(user, i)">
+    <div class="online"></div>
+    <img [src]="user.img" />
   </div>
 
   <button (click)="toggleFollow()" [ngClass]="[following ? followclass : '', follow]">
-    <span *ngIf="following ">&#10004; Following</span>
-    <span *ngIf="!following ">Follow</span>
+    <span *ngIf="following">&#10004; Following</span>
+    <span *ngIf="!following">Follow</span>
   </button>
 
   <h2 id="profile-name" class="profile-name">
-    <span *ngIf="page==='group' " class="user-trip ">{{ selectedUser.trips[0] }}</span>
-    <span *ngIf="page !=='group' ">{{ selectedUser.name }}</span>
+    <span *ngIf="page==='group'" class="user-trip ">{{ selectedUser.trips[0] }}</span>
+    <span *ngIf="page !=='group'">{{ selectedUser.name }}</span>
   </h2>
 
   <div (click)="addPlace() " class="side-icon" id="side-icon">
-    <icon-base *ngIf="page==='index' " iconName="mail " iconColor="white " width="22 " height="22 ">
+    <icon-base *ngIf="page==='index'" iconName="mail" iconColor="white" width="22" height="22">
       <svg:g icon-mail></svg:g>
     </icon-base>
 
-    <icon-base *ngIf="page !=='index' " iconName="plus " class="plus " width="18 " height="18 ">
+    <icon-base *ngIf="page !=='index'" iconName="plus" class="plus" width="18" height="18">
       <svg:g icon-plus />
     </icon-base>
   </div>
 
-  <div id="saveinfo " class="saveinfo ">Saved!</div>
+  <div id="saveinfo" class="saveinfo">Saved!</div>
 
   <aside id="aside ">
     <p class="map-pin ">
-      <icon-base iconName="map pin " width="18 " height="18 ">
+      <icon-base iconName="map pin" width="18" height="18">
         <svg:g icon-map-pin />
       </icon-base>
       United States
     </p>
 
-    <p class="calendar ">
-      <icon-base iconName="calendar " width="18 " height="18 ">
+    <p class="calendar">
+      <icon-base iconName="calendar" width="18" height="18">
         <svg:g icon-calendar />
       </icon-base>
       {{ selectedUser.days }} days traveling


### PR DESCRIPTION
Fixes #18

The problem was in spaces in `width`/`height` attributes in SVG elements. FF invalidates such values. Fixed template formatting.